### PR TITLE
Jenkins logging fix, array to bytes fix, req body keys fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ if you application can cope with the fuzzed parameters. Does not require coding.
 ### Work in progress
 - [API Blueprint][]
 
+## Pre-requirements
+1. Python3
+2. libcurl4-openssl-dev libssl-dev (for pycurl)
+
 ## Installation
 
 Fetch the most recent code from GitHub

--- a/apifuzzer/fuzzer_target.py
+++ b/apifuzzer/fuzzer_target.py
@@ -320,7 +320,8 @@ class FuzzerTarget(ServerTarget):
         except (UnicodeDecodeError, UnicodeEncodeError) as e:  # request failure such as InvalidHeader
             self.report_add_basic_msg(('Failed to parse http response code, exception occurred: %s', e))
 
-    def fix_data(self, data):
+    @staticmethod
+    def fix_data(data):
         new_data = {}
         for data_key, data_value in data.items():
             new_key = data_key.split('|')[-1]

--- a/apifuzzer/fuzzer_target.py
+++ b/apifuzzer/fuzzer_target.py
@@ -232,8 +232,9 @@ class FuzzerTarget(ServerTarget):
                 _req_url.append(url_part.strip('/'))
             kwargs.pop('url')
             # Replace back the placeholder for '/'
-            # (this happens in expand_path_variables, but if we don't have any path_variables, it won't)
-            request_url = '/'.join(_req_url).replace('+','/')
+            # (this happens in expand_path_variables,
+            # but if we don't have any path_variables, it won't)
+            request_url = '/'.join(_req_url).replace('+', '/')
             query_params = None
             if kwargs.get('params') is not None:
                 query_params = self.format_pycurl_query_param(request_url, kwargs.get('params', {}))

--- a/apifuzzer/fuzzer_target.py
+++ b/apifuzzer/fuzzer_target.py
@@ -244,7 +244,8 @@ class FuzzerTarget(ServerTarget):
                 kwargs.pop('path_variables')
             if kwargs.get('data') is not None:
                 kwargs['data'] = self.fix_data(kwargs.get('data'))
-            request_url = '{}{}'.format(request_url, query_params)
+            if query_params is not None:
+                request_url = '{}{}'.format(request_url, query_params)
             self.logger.info('Request URL : {}'.format(request_url))
             method = kwargs['method']
             if isinstance(method, Bits):

--- a/apifuzzer/utils.py
+++ b/apifuzzer/utils.py
@@ -52,21 +52,25 @@ def get_sample_data_by_type(param_type):
         u'integer': 1,
         u'number': 667.5,
         u'boolean': False,
-        u'array': ['a', 'b', 'c']
+        u'array': [1, 2, 3] # transform_data_to_bytes complains when this array contains strings.
     }
     return types.get(param_type, b'\x00')
 
 
-def set_logger(level='warning'):
-    handler = logging.StreamHandler()
-    if os.path.exists('/dev/log'):
-        handler = SysLogHandler(address='/dev/log', facility=SysLogHandler.LOG_LOCAL2)
-    handler.setFormatter(Formatter('%(process)d [%(levelname)s] %(name)s: %(message)s'))
-    logger = logging.getLogger()
+def set_logger(level='warning', basic_output=false):
+    fmt = '%(process)d [%(levelname)s] %(name)s: %(message)s'
+    if (basic_output):
+        logging.basicConfig(format=fmt)
+        logger = logging.getLogger()
+    else:
+        handler = logging.StreamHandler()
+        if os.path.exists('/dev/log'):
+            handler = SysLogHandler(address='/dev/log', facility=SysLogHandler.LOG_LOCAL2)
+        handler.setFormatter(Formatter('%(process)d [%(levelname)s] %(name)s: %(message)s'))
+        logger = logging.getLogger()
+        logger.addHandler(handler)
     logger.setLevel(level=level.upper())
-    logger.addHandler(handler)
     return logger
-
 
 def transform_data_to_bytes(data_in):
     if isinstance(data_in, float):

--- a/apifuzzer/utils.py
+++ b/apifuzzer/utils.py
@@ -57,7 +57,7 @@ def get_sample_data_by_type(param_type):
     return types.get(param_type, b'\x00')
 
 
-def set_logger(level='warning', basic_output=false):
+def set_logger(level='warning', basic_output=False):
     fmt = '%(process)d [%(levelname)s] %(name)s: %(message)s'
     if (basic_output):
         logging.basicConfig(format=fmt)

--- a/fuzzer.py
+++ b/fuzzer.py
@@ -21,7 +21,7 @@ from apifuzzer.utils import set_logger
 
 class Fuzzer(object):
 
-    def __init__(self, api_resources, report_dir, test_level, log_level, alternate_url=None, test_result_dst=None,
+    def __init__(self, api_resources, report_dir, test_level, log_level, basic_output, alternate_url=None, test_result_dst=None,
                  auth_headers=None):
         self.api_resources = api_resources
         self.base_url = None
@@ -31,7 +31,7 @@ class Fuzzer(object):
         self.report_dir = report_dir
         self.test_result_dst = test_result_dst
         self.auth_headers = auth_headers if auth_headers else {}
-        self.logger = set_logger(log_level)
+        self.logger = set_logger(log_level, basic_output)
         self.logger.info('APIFuzzer initialized')
 
     def prepare(self):
@@ -104,6 +104,12 @@ if __name__ == '__main__':
                         dest='log_level',
                         default='warning',
                         choices=[level.lower() for level in levelNames if isinstance(level, str)])
+    parser.add_argument('--basic_output',
+                        type=bool,
+                        required=False,
+                        help='Use basic output for logging (useful if running in jenkins). Example --basic_output=true
+                        dest='basic_output',
+                        default=False) # Useful if running in jenkins.
     parser.add_argument('--headers',
                         type=json_data,
                         required=False,
@@ -125,6 +131,7 @@ if __name__ == '__main__':
                   alternate_url=args.alternate_url,
                   test_result_dst=args.test_result_dst,
                   log_level=args.log_level,
+                  basic_output=args.basic_output
                   auth_headers=args.headers
                   )
     prog.prepare()

--- a/fuzzer.py
+++ b/fuzzer.py
@@ -131,7 +131,7 @@ if __name__ == '__main__':
                   alternate_url=args.alternate_url,
                   test_result_dst=args.test_result_dst,
                   log_level=args.log_level,
-                  basic_output=args.basic_output
+                  basic_output=args.basic_output,
                   auth_headers=args.headers
                   )
     prog.prepare()

--- a/fuzzer.py
+++ b/fuzzer.py
@@ -54,6 +54,16 @@ class Fuzzer(object):
         fuzzer.set_interface(interface)
         fuzzer.start()
 
+def str2bool(v):
+    if isinstance(v, bool):
+       return v
+    if v.lower() in ('yes', 'true', 't', 'y', '1', 'True', 'T'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0', 'False', 'F'):
+        return False
+    else:
+        raise argparse.ArgumentTypeError('Boolean value expected.')
+
 
 if __name__ == '__main__':
 
@@ -105,7 +115,7 @@ if __name__ == '__main__':
                         default='warning',
                         choices=[level.lower() for level in levelNames if isinstance(level, str)])
     parser.add_argument('--basic_output',
-                        type=bool,
+                        type=str2bool,
                         required=False,
                         help='Use basic output for logging (useful if running in jenkins). Example --basic_output=True',
                         dest='basic_output',

--- a/fuzzer.py
+++ b/fuzzer.py
@@ -107,7 +107,7 @@ if __name__ == '__main__':
     parser.add_argument('--basic_output',
                         type=bool,
                         required=False,
-                        help='Use basic output for logging (useful if running in jenkins). Example --basic_output=True'
+                        help='Use basic output for logging (useful if running in jenkins). Example --basic_output=True',
                         dest='basic_output',
                         default=False) # Useful if running in jenkins.
     parser.add_argument('--headers',

--- a/fuzzer.py
+++ b/fuzzer.py
@@ -107,7 +107,7 @@ if __name__ == '__main__':
     parser.add_argument('--basic_output',
                         type=bool,
                         required=False,
-                        help='Use basic output for logging (useful if running in jenkins). Example --basic_output=True
+                        help='Use basic output for logging (useful if running in jenkins). Example --basic_output=True'
                         dest='basic_output',
                         default=False) # Useful if running in jenkins.
     parser.add_argument('--headers',

--- a/fuzzer.py
+++ b/fuzzer.py
@@ -107,7 +107,7 @@ if __name__ == '__main__':
     parser.add_argument('--basic_output',
                         type=bool,
                         required=False,
-                        help='Use basic output for logging (useful if running in jenkins). Example --basic_output=true
+                        help='Use basic output for logging (useful if running in jenkins). Example --basic_output=True
                         dest='basic_output',
                         default=False) # Useful if running in jenkins.
     parser.add_argument('--headers',


### PR DESCRIPTION
A few fixes which i made while using this:
1. On jenkins i couldn't for the life of me get any debug output, only minimal logs were displayed, fixed this by using basic logging config which can be enabled using --basic_output=True (False or omitted leaves the old behaviour)
2. When you have path paramaters, the code also fixes the url in expand_path_variables, i put the same fix (replace('+','/')) above so that it happens when you don't have path params also
3. For post bodys the attribute key is not being fixed, (it's still something like "url | method | paramkey", so i fixed that in fix_body the same way that you did for path params.
4. With no query params the url ended up like "<url>None", so check for none in query params.

Also, a heads up: you're .editorconfig specifies `indent_style = space` but the github checks are wanting tabs.