### PR TITLE
fuzzer: call stop(), removing need for check in _end_message

### DIFF
--- a/apifuzzer/server_fuzzer.py
+++ b/apifuzzer/server_fuzzer.py
@@ -31,15 +31,6 @@ class OpenApiServerFuzzer(ServerFuzzer):
         self.logger.info('Logger initialized')
         super(OpenApiServerFuzzer, self).__init__()
 
-    def _end_message(self):
-        super(OpenApiServerFuzzer, self)._end_message()
-        # Sometimes Kitty has stopped the fuzzer before it has finished the work. We can't continue, but can log
-        self.logger.info('Stop fuzzing session_info: {}'.format(self.session_info.as_dict()))
-        test_list_str_end = self.session_info.as_dict().get('test_list_str', '0-0').split('-', 1)[1].strip()
-        if self.session_info.as_dict().get('end_index') != int(test_list_str_end):
-            self.logger.error('Fuzzer want to exit before the end of the tests')
-        self._exit_now(None, None)
-
     def _transmit(self, node):
         payload = {}
         for key in ['url', 'method']:

--- a/fuzzer.py
+++ b/fuzzer.py
@@ -52,6 +52,7 @@ class Fuzzer(object):
         fuzzer.set_target(target)
         fuzzer.set_interface(interface)
         fuzzer.start()
+        fuzzer.stop()
 
 
 def str2bool(v):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -53,18 +53,17 @@ class BaseTest:
         Call APIFuzzer with the given api definition
         :type api_resources: dict
         """
-        with pytest.raises(SystemExit):
-            prog = Fuzzer(api_resources=api_resources,
-                          report_dir=self.report_dir,
-                          test_level=1,
-                          alternate_url=self.test_app_url,
-                          test_result_dst=None,
-                          log_level='Debug',
-                          basic_output=False,
-                          auth_headers={}
-                          )
-            prog.prepare()
-            prog.run()
+        prog = Fuzzer(api_resources=api_resources,
+                      report_dir=self.report_dir,
+                      test_level=1,
+                      alternate_url=self.test_app_url,
+                      test_result_dst=None,
+                      log_level='Debug',
+                      basic_output=False,
+                      auth_headers={}
+                      )
+        prog.prepare()
+        prog.run()
 
     def get_last_report_file(self):
         self.report_files = os.listdir(self.report_dir)


### PR DESCRIPTION
Hello, I was doing investigative work on fuzz testing OpenAPI endpoints and came across your repo. When trying to use it as a library (I understand this is probably not a currently supported use case) I found it called sys.exit() - terminating before I could process the reports. This led me to the commentary in `_end_message`, once commented out caused the process to hang. Tracing what started the thread brought me to fuzzer.py which calls kitty.start(), but a minor omission of kitty.stop() prevented the thread.join().

This patch adds the kitty.stop() which removes the necessity of _end_message().