### PR TITLE
Fix JSON failed parse input file on WSL

### DIFF
--- a/apifuzzer/utils.py
+++ b/apifuzzer/utils.py
@@ -146,7 +146,7 @@ def get_api_definition_from_file(src_file):
         with open(src_file, mode='rb') as f:
             api_definition = f.read()
         try:
-            return json.loads(api_definition)
+            return json.loads(api_definition.decode('utf-8'))
         except ValueError as e:
             print('Failed to load input as JSON, maybe YAML?')
         try:

--- a/docs/apifuzzer.base_template.rst
+++ b/docs/apifuzzer.base_template.rst
@@ -1,7 +1,0 @@
-apifuzzer.base\_template module
-===============================
-
-.. automodule:: apifuzzer.base_template
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/apifuzzer.custom_fuzzers.rst
+++ b/docs/apifuzzer.custom_fuzzers.rst
@@ -1,7 +1,0 @@
-apifuzzer.custom\_fuzzers module
-================================
-
-.. automodule:: apifuzzer.custom_fuzzers
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/apifuzzer.fuzzer_target.rst
+++ b/docs/apifuzzer.fuzzer_target.rst
@@ -1,7 +1,0 @@
-apifuzzer.fuzzer\_target module
-===============================
-
-.. automodule:: apifuzzer.fuzzer_target
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/apifuzzer.rst
+++ b/docs/apifuzzer.rst
@@ -4,20 +4,67 @@ apifuzzer package
 Submodules
 ----------
 
-.. toctree::
+apifuzzer.apifuzzer\_report module
+----------------------------------
 
-   apifuzzer.base_template
-   apifuzzer.custom_fuzzers
-   apifuzzer.fuzzer_target
-   apifuzzer.server_fuzzer
-   apifuzzer.swagger_template_generator
-   apifuzzer.template_generator_base
-   apifuzzer.utils
+.. automodule:: apifuzzer.apifuzzer_report
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+apifuzzer.base\_template module
+-------------------------------
+
+.. automodule:: apifuzzer.base_template
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+apifuzzer.custom\_fuzzers module
+--------------------------------
+
+.. automodule:: apifuzzer.custom_fuzzers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+apifuzzer.server\_fuzzer module
+-------------------------------
+
+.. automodule:: apifuzzer.server_fuzzer
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+apifuzzer.swagger\_template\_generator module
+---------------------------------------------
+
+.. automodule:: apifuzzer.swagger_template_generator
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+apifuzzer.template\_generator\_base module
+------------------------------------------
+
+.. automodule:: apifuzzer.template_generator_base
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+apifuzzer.utils module
+----------------------
+
+.. automodule:: apifuzzer.utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 
 Module contents
 ---------------
 
 .. automodule:: apifuzzer
-    :members:
-    :undoc-members:
-    :show-inheritance:
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/apifuzzer.server_fuzzer.rst
+++ b/docs/apifuzzer.server_fuzzer.rst
@@ -1,7 +1,0 @@
-apifuzzer.server\_fuzzer module
-===============================
-
-.. automodule:: apifuzzer.server_fuzzer
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/apifuzzer.swagger_template_generator.rst
+++ b/docs/apifuzzer.swagger_template_generator.rst
@@ -1,7 +1,0 @@
-apifuzzer.swagger\_template\_generator module
-=============================================
-
-.. automodule:: apifuzzer.swagger_template_generator
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/apifuzzer.template_generator_base.rst
+++ b/docs/apifuzzer.template_generator_base.rst
@@ -1,7 +1,0 @@
-apifuzzer.template\_generator\_base module
-==========================================
-
-.. automodule:: apifuzzer.template_generator_base
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/apifuzzer.utils.rst
+++ b/docs/apifuzzer.utils.rst
@@ -1,7 +1,0 @@
-apifuzzer.utils module
-======================
-
-.. automodule:: apifuzzer.utils
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,3 +62,9 @@ if not on_rtd:
     html_theme = 'sphinx_rtd_theme'
     html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
     html_style = 'css/custom.css'
+
+"""
+Documentation update:
+- remove *.rst under docs except index.rst
+- run: sphinx-apidoc apifuzzer/ -o docs/
+"""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,8 +2,24 @@
 import os
 import sys
 
+from mock import Mock as MagicMock
+
 path = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir))
 sys.path.insert(0, path)
+
+
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+        return Mock()
+
+    @classmethod
+    def __getitem__(cls, name):
+        return Mock()
+
+
+MOCK_MODULES = ['pycurl']
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 project = 'APIfuzzer'
 version = '0.9'

--- a/docs/requirements.readthedocs.txt
+++ b/docs/requirements.readthedocs.txt
@@ -1,0 +1,2 @@
+kittyfuzzer==0.7.4
+ruamel.yaml==0.16.7


### PR DESCRIPTION
Ubuntu on Widows (versioned Linux 4.4.0-18362-Microsoft #476-Microsoft Fri Nov 01 16:53:00 PST 2019 x86_64 x86_64 x86_64 GNU/Linux) was failing while opening any valid JSON file (no matter using local file or network) with error "Failed to parse input file, exit". This commit fixes it.